### PR TITLE
adds test and support for getting count for Server version 10.0

### DIFF
--- a/geoservices.gemspec
+++ b/geoservices.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "geoservices"
-  s.version = "0.0.12"
+  s.version = "0.0.13"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Andrew Turner"]

--- a/lib/geoservices/queryable.rb
+++ b/lib/geoservices/queryable.rb
@@ -18,7 +18,8 @@ module Geoservice
       unless self.metadata['currentVersion'].nil?
         query(layer_idx, options.merge(:returnCountOnly => true))
       else
-        # Return count only is not supported by versions lower than 10.1
+        # Neither returnCountOnly nor currentVersion are supported for layers @ lower than 10.0 SP1 
+        # http://resources.arcgis.com/en/help/rest/apiref/
         # So request all the object ids and count them up
         response = query(layer_idx, options.merge(:where => '1=1', :returnIdsOnly => true))
         return {'count' => response['objectIds'].length}

--- a/lib/geoservices/queryable.rb
+++ b/lib/geoservices/queryable.rb
@@ -14,7 +14,15 @@ module Geoservice
     # returns nil if the layer does not have the Capability: Query
     def count(layer_idx=0, options={})
       return nil unless self.metadata["capabilities"] =~ /Query/
-      query(layer_idx, options.merge(:returnCountOnly => true))
+      # Current Version is not returned at lower than 10.1
+      unless self.metadata['currentVersion'].nil?
+        query(layer_idx, options.merge(:returnCountOnly => true))
+      else
+        # Return count only is not supported by versions lower than 10.1
+        # So request all the object ids and count them up
+        response = query(layer_idx, options.merge(:where => '1=1', :returnIdsOnly => true))
+        return {'count' => response['objectIds'].length}
+      end
     end
   end
 end

--- a/spec/geoservices/service_spec.rb
+++ b/spec/geoservices/service_spec.rb
@@ -40,4 +40,14 @@ describe Geoservice do
       expect(@service.layers("Watches/Warnings")['name']).to eq("Watches/Warnings")
     end
   end
+
+  context "getting a map service layer at version 10.0" do
+    before :all do
+      @service = Geoservice::MapService.new(:url => "http://sampleserver3.arcgisonline.com/ArcGIS/rest/services/Earthquakes/EarthquakesFromLastSevenDays/MapServer")
+    end
+
+    it "should be countable" do
+      expect(@service.count(0)["count"] > 0).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
Fall back to requesting all the object IDs and counting them up if the server doesn't support returnCountOnly.

Resolves https://github.com/ArcGIS/composer/issues/6981
