### PR TITLE
Update SSL version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GeoServices Ruby Library
 
-This library is a simple wrapper around the GeoServices API. You can see the [GeoServices REST Specification](http://www.esri.com/industries/landing-pages/geoservices/geoservices) or the [Getting Started](https://services.arcgis.com/help/index.html?overview.html)
+This library is a simple wrapper around the GeoServices API. You can see the [GeoServices REST Specification](https://developers.arcgis.com/rest/) or the [Getting Started](https://developers.arcgis.com/rest/services-reference/get-started-with-the-services-directory.htm)
 
 If you have not worked with GeoServices before, there are a few basic concepts to get started:
 
@@ -58,7 +58,7 @@ puts query["features"]
 
 ### Testing
 
-geoservices-ruby uses RSpec for tests. 
+geoservices-ruby uses RSpec for tests.
 
     $ rake rspec
 
@@ -68,8 +68,8 @@ geoservices-ruby uses RSpec for tests.
 
 ## Resources
 
-* [GeoServices REST Specification](http://www.esri.com/industries/landing-pages/geoservices/geoservices)
-* [GeoServices Getting Started](https://services.arcgis.com/help/index.html?overview.html)
+* [GeoServices REST Specification](https://developers.arcgis.com/rest/)
+* [GeoServices Getting Started](https://developers.arcgis.com/rest/services-reference/get-started-with-the-services-directory.htm)
 
 ## Licensing
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/geoservices/base.rb
+++ b/lib/geoservices/base.rb
@@ -30,7 +30,7 @@ module Geoservice
       http = Net::HTTP.new(uri.host, secure ? 443 : uri.port)
       if(secure || uri.scheme == "https")
         http.use_ssl = true
-        http.ssl_version = :TLSv1
+        http.ssl_version = :TLSv1_2
         http.verify_mode = OpenSSL::SSL::VERIFY_NONE
       end
 


### PR DESCRIPTION
Using the 0.10 version of the gem I get:
​
```
OpenSSL::SSL::SSLError (SSL_connect returned=1 errno=0 state=error: tlsv1 alert protocol version)
```

when connecting to `https://services.arcgis.com`. This PR fixes the issue by updating from:
```ruby
http.ssl_version = :TLSv1
```

to:
```ruby
http.ssl_version = :TLSv1_2
```
